### PR TITLE
Show OGP card even with local URL (#1)

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -85,7 +85,7 @@ class FetchLinkCardService < BaseService
 
   def bad_url?(uri)
     # Avoid local instance URLs and invalid URLs
-    uri.host.blank? || TagManager.instance.local_url?(uri.to_s) || !%w(http https).include?(uri.scheme)
+    uri.host.blank? || !%w(http https).include?(uri.scheme)
   end
 
   def mention_link?(anchor)

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -21,7 +21,7 @@ module Mastodon
     end
 
     def suffix
-      "+yuichodon#{ENV.fetch('MASTODON_VERSION_SUFFIX', '')}"
+      '+yuicho_230813'
     end
 
     def to_a


### PR DESCRIPTION
自サーバーのURLをトゥートした時でもOGPのプレビューカードが表示されるように修正